### PR TITLE
compatibility with dbt v0.13.0rc1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.egg-info
+env/
+__pycache__/

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -23,14 +23,11 @@
           NULL as numeric_scale
 
       from
-      {{ information_schema_name(relation.database) }}.columns
+      {{ relation.information_schema('columns') }}
 
       where {{ presto_ilike('table_name', relation.identifier) }}
         {% if relation.schema %}
         and {{ presto_ilike('table_schema', relation.schema) }}
-        {% endif %}
-        {% if relation.database %}
-        and {{ presto_ilike('table_catalog', relation.database) }}
         {% endif %}
       order by ordinal_position
 
@@ -41,7 +38,7 @@
 {% endmacro %}
 
 
-{% macro presto__list_relations_without_caching(database, schema) %}
+{% macro presto__list_relations_without_caching(information_schema, schema) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     select
       table_catalog as database,
@@ -51,9 +48,8 @@
            when table_type = 'VIEW' then 'view'
            else table_type
       end as table_type
-    from {{ information_schema_name(database) }}.tables
+    from {{ information_schema }}.tables
     where {{ presto_ilike('table_schema', schema) }}
-      and {{ presto_ilike('table_catalog', database) }}
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/dbt/include/presto/macros/catalog.sql
+++ b/dbt/include/presto/macros/catalog.sql
@@ -1,8 +1,8 @@
 
-{% macro presto__get_catalog() -%}
+{% macro presto__get_catalog(information_schemas) -%}
     {%- call statement('catalog', fetch_result=True) -%}
     select * from (
-    {% for database in databases %}
+    {% for information_schema in information_schemas %}
 
         (
             with tables as (
@@ -14,7 +14,7 @@
                     table_type as "table_type",
                     null as "table_owner"
 
-                from {{ information_schema_name(database) }}.tables
+                from {{ information_schema }}.tables
 
             ),
 
@@ -31,15 +31,14 @@
                     data_type as "column_type",
                     null as "column_comment"
 
-                from {{ information_schema_name(database) }}.columns
+                from {{ information_schema }}.columns
 
             )
 
             select *
             from tables
             join columns using ("table_database", "table_schema", "table_name")
-            where "table_schema" != 'INFORMATION_SCHEMA'
-              and "table_database" = {{ adapter.quote_as_configured(database, "database").replace('"', "'") }}
+            where "table_schema" != 'information_schema'
             order by "column_index"
         )
         {% if not loop.last %} union all {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from distutils.core import setup
 
 package_name = "dbt-presto"
-package_version = "0.13.0a1"
+package_version = "0.13.0rc1"
 description = """The presto adpter plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
- Update information schema macro signatures and SQL to be compatible with 0.13.0rc1 changes

Tested this by running dbt models twice (to confirm the info schema types were picked up), then running `dbt docs generate` and inspecting the docs site.