### PR TITLE
Support for 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ Use --verbose for detailed stacktrace.
 *** schemaTool failed ***
 ```
 
-Solution:
-```
-# run this against the hive metastore (port forwarded to 10005 by default)
+**Solution:** Drop (or rename) the public schema to allow the init script to recreate the metastore from scratch. **Only run this against a test Presto deployment. Do not run this in production!**
+```sql
+-- run this against the hive metastore (port forwarded to 10005 by default)
+-- DO NOT RUN THIS IN PRODUCTION!
+
 drop schema public cascade;
 create schema public;
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,37 @@ hive.allow-rename-table=true
 
 -   Want to report a bug or request a feature? Let us know on [Slack](http://slack.getdbt.com/), or open [an issue](https://github.com/fishtown-analytics/dbt-spark/issues/new).
 
+### Running tests
+
+Run a Presto server locally:
+
+```
+cd docker/
+./init.bash
+```
+
+If you see errors while about "inconsistent state" while bringing up presto,
+you may need to drop and re-create the `public` schema in the hive metastore:
+```
+# Example error
+
+Initialization script hive-schema-2.3.0.postgres.sql
+Error: ERROR: relation "BUCKETING_COLS" already exists (state=42P07,code=0)
+org.apache.hadoop.hive.metastore.HiveMetaException: Schema initialization FAILED! Metastore state would be inconsistent !!
+Underlying cause: java.io.IOException : Schema script failed, errorcode 2
+Use --verbose for detailed stacktrace.
+*** schemaTool failed ***
+```
+
+Solution:
+```
+# run this against the hive metastore (port forwarded to 10005 by default)
+drop schema public cascade;
+create schema public;
+```
+
+You probably should be slightly less reckless than this.
+
 ## Code of Conduct
 
 Everyone interacting in the dbt project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -94,3 +94,23 @@
 {% macro presto__load_csv_rows(model) %}
   {{ return(basic_load_csv_rows(model, 1000)) }}
 {% endmacro %}
+
+
+{% macro presto__list_schemas(database) -%}
+  {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}
+    select distinct schema_name
+    from {{ information_schema_name(database) }}.schemata
+  {% endcall %}
+  {{ return(load_result('list_schemas').table) }}
+{% endmacro %}
+
+
+{% macro presto__check_schema_exists(information_schema, schema) -%}
+  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) -%}
+        select count(*)
+        from {{ information_schema }}.schemata
+        where {{ presto_ilike('catalog_name', information_schema.database) }}
+          and {{ presto_ilike('schema_name', schema) }}
+  {%- endcall %}
+  {{ return(load_result('check_schema_exists').table) }}
+{% endmacro %}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,8 @@ services:
 
   hive-metastore-db:
     image: postgres
+    ports:
+      - "10005:5432"
     environment:
       POSTGRES_USER: "root"
       POSTGRES_PASSWORD: "password"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from distutils.core import setup
 
 package_name = "dbt-presto"
-package_version = "0.13.0rc1"
+package_version = "0.14.0"
 description = """The presto adpter plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
- update instructions for running presto locally in docker
- use per-thread connections as implemented in 0.14.0
- bump to use dbt v0.14.0
- fix for "base" adapter macros which implemented unsupported SQL (replace `ilike` with the presto equivalent)