### PR TITLE
fix for setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 from setuptools import find_packages
 from distutils.core import setup
+import os
+
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, 'README.md')) as f:
+    long_description = f.read()
+
 
 package_name = "dbt-presto"
 package_version = "0.14.0"
@@ -9,11 +15,15 @@ description = """The presto adpter plugin for dbt (data build tool)"""
 setup(
     name=package_name,
     version=package_version,
+
     description=description,
-    long_description_content_type=description,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+
     author='Fishtown Analytics',
     author_email='info@fishtownanalytics.com',
     url='https://github.com/fishtown-analytics/dbt',
+
     packages=find_packages(),
     package_data={
         'dbt': [


### PR DESCRIPTION
Fixes `long_description_content_type` which prevented this module from being uploaded to pypi. Additionally, correctly set the `long_description` to be the contents of the README.