### PR TITLE
Feature/override materializations

### DIFF
--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -70,6 +70,15 @@
 {% endmacro %}
 
 
+{% macro presto__create_view_as(relation, sql) -%}
+  create or replace view
+    {{ relation }}
+  as (
+    {{ sql }}
+  );
+{% endmacro %}
+
+
 {% macro presto__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
     drop {{ relation.type }} if exists {{ relation }}
@@ -86,7 +95,7 @@
 
 {% macro presto__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}
-    alter table {{ from_relation }} rename to {{ to_relation }}
+    alter {{ from_relation.type }} {{ from_relation }} rename to {{ to_relation }}
   {%- endcall %}
 {% endmacro %}
 

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -73,9 +73,9 @@
 {% macro presto__create_view_as(relation, sql) -%}
   create or replace view
     {{ relation }}
-  as (
+  as
     {{ sql }}
-  );
+  ;
 {% endmacro %}
 
 

--- a/dbt/include/presto/macros/materializations/table.sql
+++ b/dbt/include/presto/macros/materializations/table.sql
@@ -13,9 +13,6 @@
                                                       database=database,
                                                       type='table') -%}
 
-  /*
-      See ../view/view.sql for more information about this relation.
-  */
   {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}
   {%- set backup_relation = api.Relation.create(identifier=backup_identifier,
                                                 schema=schema,

--- a/dbt/include/presto/macros/materializations/table.sql
+++ b/dbt/include/presto/macros/materializations/table.sql
@@ -1,0 +1,61 @@
+{% materialization table, adapter='presto' %}
+  {%- set identifier = model['alias'] -%}
+  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}
+  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='table') -%}
+  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,
+                                                      schema=schema,
+                                                      database=database,
+                                                      type='table') -%}
+
+  /*
+      See ../view/view.sql for more information about this relation.
+  */
+  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}
+  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type=backup_relation_type) -%}
+
+  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+
+
+  -- drop the temp relations if they exists for some reason
+  {{ adapter.drop_relation(intermediate_relation) }}
+  {{ adapter.drop_relation(backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_table_as(False, intermediate_relation, sql) }}
+  {%- endcall %}
+
+  -- cleanup
+  {% if old_relation is not none %}
+      {{ adapter.rename_relation(old_relation, backup_relation) }}
+  {% endif %}
+
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  -- finally, drop the existing/backup relation after the commit
+  {{ drop_relation_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/dbt/include/presto/macros/materializations/view.sql
+++ b/dbt/include/presto/macros/materializations/view.sql
@@ -1,0 +1,3 @@
+{% materialization view, adapter='presto' -%}
+    {{ return(create_or_replace_view()) }}
+{%- endmaterialization %}


### PR DESCRIPTION
Override default materializations to fix issues around switching between them. While here, improve `view` functionality by taking advantage of `create or replace view` support on Presto.

### Table

* Rename the `old_relation` instead of the `target_relation`, to handle cases where `old_relation.type != target_relation.type`. Presto fix for https://github.com/fishtown-analytics/dbt/issues/2161

### View

* Use [`create_or_replace_view()`](https://github.com/fishtown-analytics/dbt/blob/dev/barbara-gittings/core/dbt/include/global_project/macros/materializations/view/create_or_replace_view.sql) materialization approach
* Exclude parens. Fixes #11.