### PR TITLE
Add bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.2
+current_version = 0.15.3
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,26 @@
+[bumpversion]
+current_version = 0.15.2
+parse = (?P<major>\d+)
+	\.(?P<minor>\d+)
+	\.(?P<patch>\d+)
+	((?P<prerelease>[a-z]+)(?P<num>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{prerelease}{num}
+	{major}.{minor}.{patch}
+commit = False
+tag = False
+
+[bumpversion:part:prerelease]
+first_value = a
+values = 
+	a
+	b
+	rc
+
+[bumpversion:part:num]
+first_value = 1
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:docker/dbt/Dockerfile]
+

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,3 @@
+bumpversion
+wheel
+twine

--- a/docker/dbt/Dockerfile
+++ b/docker/dbt/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.1-slim-buster
 
-ENV DBT_VERSION "0.15.2"
+ENV DBT_VERSION "0.15.3"
 ENV DBT_DIR /opt/dbt-presto
 
 RUN apt-get update && \

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 
 
 package_name = "dbt-presto"
-package_version = "0.15.2"
+package_version = "0.15.3"
 description = """The presto adpter plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
- Add a `.bumpversion.cfg`
- add release tools to `dev_requirements.txt`
- Use bumpversion to upgrade from 0.15.2 to 0.15.3.