### PR TITLE
Fix docs generation in 0.16

### DIFF
--- a/dbt/include/presto/macros/catalog.sql
+++ b/dbt/include/presto/macros/catalog.sql
@@ -1,8 +1,7 @@
 
-{% macro presto__get_catalog(information_schemas) -%}
+{% macro presto__get_catalog(information_schema, schemas) -%}
     {%- call statement('catalog', fetch_result=True) -%}
     select * from (
-    {% for information_schema in information_schemas %}
 
         (
             with tables as (
@@ -39,11 +38,14 @@
             from tables
             join columns using ("table_database", "table_schema", "table_name")
             where "table_schema" != 'information_schema'
+            and (
+            {%- for schema in schemas -%}
+              upper("table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+            {%- endfor -%}
+            )
             order by "column_index"
         )
-        {% if not loop.last %} union all {% endif %}
 
-    {% endfor %}
     )
   {%- endcall -%}
 


### PR DESCRIPTION
### Fix

* Update `get_catalog` to take two arguments, `information_schema` and `schemas`

### Why?

* `dbt-presto==0.16.0` didn't account for the [breaking change](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/CHANGELOG.md#breaking-changes-2) in 0.16.0
* We've added `dbt docs generate` as a step in integration tests for Presto