### PR TITLE
Added sample_profiles.yml so that adapter works with new --adapter option of dbt init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## dbt-presto
 
 ### Documentation
-For more information on using Spark with dbt, consult the dbt documentation:
+For more information on using Presto with dbt, consult the dbt documentation:
 - [Presto profile](https://docs.getdbt.com/docs/profile-presto)
 
 ### Installation

--- a/dbt/include/presto/sample_profiles.yml
+++ b/dbt/include/presto/sample_profiles.yml
@@ -1,6 +1,6 @@
-my-presto-db:
-  target: dev
+default:
   outputs:
+
     dev:
       type: presto
       method: none  # optional, one of {none | ldap | kerberos}
@@ -11,3 +11,5 @@ my-presto-db:
       port: [port number]
       schema: [your dbt schema]
       threads: [1 or more]
+  
+  target: dev

--- a/dbt/include/presto/sample_profiles.yml
+++ b/dbt/include/presto/sample_profiles.yml
@@ -1,0 +1,13 @@
+my-presto-db:
+  target: dev
+  outputs:
+    dev:
+      type: presto
+      method: none  # optional, one of {none | ldap | kerberos}
+      user: [user]
+      password: [password]  # required if method is ldap or kerberos
+      database: [database name]
+      host: [hostname]
+      port: [port number]
+      schema: [your dbt schema]
+      threads: [1 or more]

--- a/dbt/include/presto/sample_profiles.yml
+++ b/dbt/include/presto/sample_profiles.yml
@@ -4,12 +4,23 @@ default:
     dev:
       type: presto
       method: none  # optional, one of {none | ldap | kerberos}
-      user: [user]
+      user: [dev_user]
       password: [password]  # required if method is ldap or kerberos
       database: [database name]
       host: [hostname]
       port: [port number]
-      schema: [your dbt schema]
+      schema: [dev_schema]
+      threads: [1 or more]
+
+    prod:
+      type: presto
+      method: none  # optional, one of {none | ldap | kerberos}
+      user: [prod_user]
+      password: [prod_password]  # required if method is ldap or kerberos
+      database: [database name]
+      host: [hostname]
+      port: [port number]
+      schema: [prod_schema]
       threads: [1 or more]
   
   target: dev

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     package_data={
         'dbt': [
             'include/presto/dbt_project.yml',
+            'include/presto/sample_profiles.yml',
             'include/presto/macros/*.sql',
             'include/presto/macros/*/*.sql',
         ]


### PR DESCRIPTION
resolves [#2533](https://github.com/fishtown-analytics/dbt/issues/2533)


### Description

Added option '--adapter' to `dbt init`, to create sample profiles.yml based on chosen adapter.

It gets the sample profiles.yml from the adapter 'includes' folder