### PR TITLE
Bump v0.17.2

### DIFF
--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2rc1
+current_version = 0.17.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2rc1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2rc1
+current_version = 0.17.2
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/dbt/adapters/presto/__version__.py
+++ b/dbt/adapters/presto/__version__.py
@@ -1,1 +1,1 @@
-version = '0.17.1'
+version = '0.17.2rc1'

--- a/dbt/adapters/presto/__version__.py
+++ b/dbt/adapters/presto/__version__.py
@@ -1,1 +1,1 @@
-version = '0.17.2rc1'
+version = '0.17.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dbt-core==0.17.2rc1
+dbt-core==0.17.2
 presto-python-client==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dbt-core==0.17.1
+dbt-core==0.17.2rc1
 presto-python-client==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ def _dbt_presto_version():
 package_version = _dbt_presto_version()
 description = """The presto adpter plugin for dbt (data build tool)"""
 
-dbt_version = '0.17.1'
+dbt_version = '0.17.2rc1'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.17.1 vs 0.17.1a1, 0.17.1.1, ...)
+# ends of it. (0.17.2rc1 vs 0.17.2rc1a1, 0.17.2rc1.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ def _dbt_presto_version():
 package_version = _dbt_presto_version()
 description = """The presto adpter plugin for dbt (data build tool)"""
 
-dbt_version = '0.17.2rc1'
+dbt_version = '0.17.2'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.17.2rc1 vs 0.17.2rc1a1, 0.17.2rc1.1, ...)
+# ends of it. (0.17.2 vs 0.17.2a1, 0.17.2.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '


### PR DESCRIPTION
No changes needed as far as removing the deprecated `release` argument, since dbt-presto does not call `execute_macro` explicitly. I wanted to double-check anyway.