### PR TITLE
Feature: upgrade to 0.18.0 release, plus tests

### DIFF
--- a/.bumpversion-dbt.cfg
+++ b/.bumpversion-dbt.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0rc1
+current_version = 0.18.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0rc1
+current_version = 0.18.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,20 +2,20 @@ version: 2.1
 
 jobs:
   unit:
+    environment:
+      DBT_INVOCATION_ENV: circle
     docker:
-      - image: fishtownanalytics/test-container:6
-        environment:
-          DBT_INVOCATION_ENV: circle
+      - image: fishtownanalytics/test-container:9
     steps:
       - checkout
       - run: tox -e flake8,unit
 
   integration:
+    environment:
+      DBT_INVOCATION_ENV: circle
+      DBT_TEST_PRESTO_HOST: presto
     docker:
-      - image: fishtownanalytics/test-container:6
-        environment:
-          DBT_INVOCATION_ENV: circle
-
+      - image: fishtownanalytics/test-container:9
       - image: fishtownanalytics/presto:1
         name: presto
     steps:
@@ -30,8 +30,6 @@ jobs:
           name: Run integration tests
           command: tox -e integration-presto
           no_output_timeout: 1h
-          environment:
-              DBT_PROFILES_DIR: /home/dbt_test_user/project/docker/dbt/
       - store_artifacts:
           path: ./logs
 

--- a/dbt/adapters/presto/__version__.py
+++ b/dbt/adapters/presto/__version__.py
@@ -1,1 +1,1 @@
-version = '0.18.0rc1'
+version = '0.18.0'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,19 +1,15 @@
 wheel
 twine
 freezegun==0.3.9
-pytest==4.4.0
+pytest==6.0.2
 mock>=1.3.0
 flake8>=3.5.0
 pytz==2017.2
 bumpversion==0.5.3
-tox==2.5.0
+tox==3.2.0
 ipdb
-pytest-xdist>=1.28.0,<2
+pytest-xdist>=2.1.0,<3
 flaky>=3.5.3,<4
 
 # Test requirements
-behave==1.2.6
-parse==1.8.4
-parse-type==0.4.2
-PyHamcrest==1.9.0
-six>=1.14.0
+pytest-dbt-adapter==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dbt-core==0.18.0rc1
+dbt-core==0.18.0
 presto-python-client==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ def _dbt_presto_version():
 package_version = _dbt_presto_version()
 description = """The presto adpter plugin for dbt (data build tool)"""
 
-dbt_version = '0.18.0rc1'
+dbt_version = '0.18.0'
 # the package version should be the dbt version, with maybe some things on the
-# ends of it. (0.18.0rc1 vs 0.18.0rc1a1, 0.18.0rc1.1, ...)
+# ends of it. (0.18.0 vs 0.18.0a1, 0.18.0.1, ...)
 if not package_version.startswith(dbt_version):
     raise ValueError(
         f'Invalid setup.py: package_version={package_version} must start with '

--- a/test/integration/presto.dbtspec
+++ b/test/integration/presto.dbtspec
@@ -1,0 +1,30 @@
+target:
+  type: presto
+  threads: 4
+  host: "{{ env_var('DBT_TEST_PRESTO_HOST', 'localhost') }}"
+  port: 8080
+  user: presto
+  database: memory
+  schema: default
+projects:
+  # incremental models aren't allowed
+  - overrides: base
+    paths:
+      models/swappable.sql: |
+        {% set materialized_var = "table" %}
+        {% if var("materialized_var", "table") == "view" %}
+          {% set materialized_var = "view" %}
+        {% endif %}
+        {{ config(materialized=materialized_var) }}
+        select * from {{ source('raw', 'seed') }}
+sequences:
+  test_dbt_empty: empty
+  test_dbt_base: base
+  test_dbt_ephemeral: ephemeral
+  # no incrementals, no snapshots
+  # test_dbt_incremental: incremental
+  # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_data_test: data_test
+  test_dbt_schema_test: schema_test
+  test_dbt_ephemeral_data_tests: data_test_ephemeral_models

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
 [testenv:unit]
 basepython = python3
 commands = /bin/bash -c '{envpython} -m pytest -v {posargs} test/unit'
+passenv = DBT_INVOCATION_ENV 
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt
@@ -19,9 +20,8 @@ deps =
 
 [testenv:integration-presto]
 basepython = python3
-changedir = dbt-integration-tests
-commands = /bin/bash -c '{envpython} -m behave -f progress3 --stop -D profile_name=presto'
-passenv = DBT_PROFILES_DIR
+commands = /bin/bash -c '{envpython} -m pytest test/integration/presto.dbtspec'
+passenv = DBT_INVOCATION_ENV DBT_TEST_PRESTO_HOST
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev_requirements.txt


### PR DESCRIPTION
Bumped the version and got presto+circle to play nicely with the new adapter integration tests.

Locally, `docker-compose up -d` followed by `tox -e integration-presto` works for me. CircleCI does similar and is also passing.