### PR TITLE
Updates catalog queries to use strict equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A dbt profile can be configured to run against Presto using the following config
 | user  | Username for authentication | Required  | `drew` |
 | password  | Password for authentication | Optional (required if `method` is `ldap` or `kerberos`)  | `none` or `abc123` |
 | database  | Specify the database to build models into | Required  | `analytics` |
-| schema  | Specify the schema to build models into | Required | `dbt_drew` |
+| schema  | Specify the schema to build models into. Note: it is not recommended to use upper or mixed case schema names | Required | `dbt_drew` |
 | host    | The hostname to connect to | Required | `127.0.0.1`  |
 | port    | The port to connect to the host on | Required | `8080` |
 | threads    | How many threads dbt should use | Optional (default is `1`) | `8` |
@@ -50,6 +50,7 @@ The following features of dbt are not implemented on Presto:
 - Archival
 - Incremental models
 
+Also, note that upper or mixed case schema names will cause catalog queries to fail. Please only use lower case schema names with this adapter.
 
 If you are interested in helping to add support for this functionality in dbt on Presto, please [open an issue](https://github.com/fishtown-analytics/dbt-presto/issues/new)!
 

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -25,9 +25,10 @@
       from
       {{ relation.information_schema('columns') }}
 
-      where {{ presto_ilike('table_name', relation.identifier) }}
+      where
+        table_name = '{{ relation.name }}'
         {% if relation.schema %}
-        and {{ presto_ilike('table_schema', relation.schema) }}
+        and table_schema = '{{ relation.schema }}'
         {% endif %}
       order by ordinal_position
 
@@ -49,7 +50,7 @@
            else table_type
       end as table_type
     from {{ relation.information_schema() }}.tables
-    where {{ presto_ilike('table_schema', relation.schema) }}
+    where table_schema = '{{ relation.schema }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
@@ -137,8 +138,8 @@
   {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) -%}
         select count(*)
         from {{ information_schema }}.schemata
-        where {{ presto_ilike('catalog_name', information_schema.database) }}
-          and {{ presto_ilike('schema_name', schema) }}
+        where catalog_name = '{{ information_schema.database }}'
+          and schema_name = '{{ schema }}'
   {%- endcall %}
   {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -3,11 +3,6 @@
 -- - list_relations_without_caching
 -- - get_columns_in_relation
 
-{% macro presto_ilike(column, value) -%}
-	regexp_like({{ column }}, '(?i)\A{{ value }}\Z')
-{%- endmacro %}
-
-
 {% macro presto__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
@@ -28,7 +23,7 @@
       where
         table_name = '{{ relation.name }}'
         {% if relation.schema %}
-        and table_schema = '{{ relation.schema }}'
+        and table_schema = '{{ relation.schema | lower }}'
         {% endif %}
       order by ordinal_position
 
@@ -50,7 +45,7 @@
            else table_type
       end as table_type
     from {{ relation.information_schema() }}.tables
-    where table_schema = '{{ relation.schema }}'
+    where table_schema = '{{ relation.schema | lower }}'
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
@@ -139,7 +134,7 @@
         select count(*)
         from {{ information_schema }}.schemata
         where catalog_name = '{{ information_schema.database }}'
-          and schema_name = '{{ schema }}'
+          and schema_name = '{{ schema | lower }}'
   {%- endcall %}
   {{ return(load_result('check_schema_exists').table) }}
 {% endmacro %}

--- a/dbt/include/presto/macros/catalog.sql
+++ b/dbt/include/presto/macros/catalog.sql
@@ -14,6 +14,10 @@
                     null as "table_owner"
 
                 from {{ information_schema }}.tables
+                where
+                    table_schema != 'information_schema'
+                    and
+                    table_schema in ('{{ schemas | join("','") | lower }}')
 
             ),
 
@@ -31,18 +35,16 @@
                     null as "column_comment"
 
                 from {{ information_schema }}.columns
+                where
+                    table_schema != 'information_schema'
+                    and
+                    table_schema in ('{{ schemas | join("','") | lower }}')
 
             )
 
             select *
             from tables
             join columns using ("table_database", "table_schema", "table_name")
-            where "table_schema" != 'information_schema'
-            and (
-            {%- for schema in schemas -%}
-              upper("table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
-            {%- endfor -%}
-            )
             order by "column_index"
         )
 


### PR DESCRIPTION
Fixes #34 (hopefully)

This PR updates the following macros in `adapter.sql` to use strict equality instead of `ilike` and make filter parameters lower case on right-hand side of filter:
- get_columns_in_relation
- list_relations_without_caching
- check_schema_exists

Also, updates `get_catalog` in `catalog.sql` to:
- push the `table_schema` predicate up for performance reasons
- make filter parameters lower case on right-hand side of filter

Presto catalogs seem to store values lower case (at least on hive). Adding a function like `upper` to the left side of a catalog filter causes some catalogs to not be able to push filter predicates down to the catalog provider, causing resource problems.
To avoid that, we assume values are stored in lower case and force incoming schema parameters to lower case as well. 