### PR TITLE
Add support for DATE columns in `dbt seed` command

### DIFF
--- a/dbt/adapters/presto/connections.py
+++ b/dbt/adapters/presto/connections.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 from dbt.helper_types import Port
 
-from datetime import datetime
+from datetime import date, datetime
 import decimal
 import re
 import prestodb
@@ -120,6 +120,9 @@ class ConnectionWrapper(object):
         elif isinstance(value, datetime):
             time_formatted = value.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
             return "TIMESTAMP '{}'".format(time_formatted)
+        elif isinstance(value, date):
+            date_formatted = value.strftime('%Y-%m-%d')
+            return "DATE '{}'".format(date_formatted)
         else:
             raise ValueError('Cannot escape {}'.format(type(value)))
 

--- a/dbt/adapters/presto/impl.py
+++ b/dbt/adapters/presto/impl.py
@@ -33,3 +33,7 @@ class PrestoAdapter(SQLAdapter):
     @classmethod
     def convert_datetime_type(cls, agate_table, col_idx):
         return "TIMESTAMP"
+
+    @classmethod
+    def convert_date_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "DATE"

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -1,7 +1,11 @@
+import string
 import unittest
-import dbt.flags as flags
-from dbt.adapters.presto import PrestoAdapter
 
+import agate
+import dbt.flags as flags
+from dbt.clients import agate_helper
+
+from dbt.adapters.presto import PrestoAdapter
 from .utils import config_from_parts_or_dicts, mock_connection
 
 
@@ -62,3 +66,81 @@ class TestPrestoAdapter(unittest.TestCase):
         self.adapter.connections.thread_connections[key] = mock_connection(
             'master')
         self.assertEqual(len(list(self.adapter.cancel_open_connections())), 0)
+
+
+class TestAdapterConversions(unittest.TestCase):
+    def _get_tester_for(self, column_type):
+        from dbt.clients import agate_helper
+        if column_type is agate.TimeDelta:  # dbt never makes this!
+            return agate.TimeDelta()
+
+        for instance in agate_helper.DEFAULT_TYPE_TESTER._possible_types:
+            if type(instance) is column_type:
+                return instance
+
+        raise ValueError(f'no tester for {column_type}')
+
+    def _make_table_of(self, rows, column_types):
+        column_names = list(string.ascii_letters[:len(rows[0])])
+        if isinstance(column_types, type):
+            column_types = [self._get_tester_for(column_types) for _ in column_names]
+        else:
+            column_types = [self._get_tester_for(typ) for typ in column_types]
+        table = agate.Table(rows, column_names=column_names, column_types=column_types)
+        return table
+
+class TestPrestoAdapterConversions(TestAdapterConversions):
+    def test_convert_text_type(self):
+        rows = [
+            ['', 'a1', 'stringval1'],
+            ['', 'a2', 'stringvalasdfasdfasdfa'],
+            ['', 'a3', 'stringval3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Text)
+        expected = ['VARCHAR', 'VARCHAR', 'VARCHAR']
+        for col_idx, expect in enumerate(expected):
+            assert PrestoAdapter.convert_text_type(agate_table, col_idx) == expect
+
+    def test_convert_number_type(self):
+        rows = [
+            ['', '23.98', '-1'],
+            ['', '12.78', '-2'],
+            ['', '79.41', '-3'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Number)
+        expected = ['INTEGER', 'DOUBLE', 'INTEGER']
+        for col_idx, expect in enumerate(expected):
+            assert PrestoAdapter.convert_number_type(agate_table, col_idx) == expect
+
+    def test_convert_boolean_type(self):
+        rows = [
+            ['', 'false', 'true'],
+            ['', 'false', 'false'],
+            ['', 'false', 'true'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Boolean)
+        expected = ['boolean', 'boolean', 'boolean']
+        for col_idx, expect in enumerate(expected):
+            assert PrestoAdapter.convert_boolean_type(agate_table, col_idx) == expect
+
+    def test_convert_datetime_type(self):
+        rows = [
+            ['', '20190101T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190102T01:01:01Z', '2019-01-01 01:01:01'],
+            ['', '20190103T01:01:01Z', '2019-01-01 01:01:01'],
+        ]
+        agate_table = self._make_table_of(rows, [agate.DateTime, agate_helper.ISODateTime, agate.DateTime])
+        expected = ['TIMESTAMP', 'TIMESTAMP', 'TIMESTAMP']
+        for col_idx, expect in enumerate(expected):
+            assert PrestoAdapter.convert_datetime_type(agate_table, col_idx) == expect
+
+    def test_convert_date_type(self):
+        rows = [
+            ['', '2019-01-01', '2019-01-04'],
+            ['', '2019-01-02', '2019-01-04'],
+            ['', '2019-01-03', '2019-01-04'],
+        ]
+        agate_table = self._make_table_of(rows, agate.Date)
+        expected = ['DATE', 'DATE', 'DATE']
+        for col_idx, expect in enumerate(expected):
+            assert PrestoAdapter.convert_date_type(agate_table, col_idx) == expect


### PR DESCRIPTION
Presto/Trino are not converting by default the string values to a date.
For this reason, the DATE values passed for insertion need to be escaped.

Resolves: #54